### PR TITLE
Wrong matcher for docker_registry_service

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -18,23 +18,23 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry_instance, :remove, name)
   end
 
-  def enable_docker_registry_config(name)
+  def enable_docker_registry_service(name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry_service, :enable, name)
   end
 
-  def disable_docker_registry_config(name)
+  def disable_docker_registry_service(name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry_service, :disable, name)
   end
 
-  def start_docker_registry_config(name)
+  def start_docker_registry_service(name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry_service, :start, name)
   end
 
-  def stop_docker_registry_config(name)
+  def stop_docker_registry_service(name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry_service, :stop, name)
   end
 
-  def restart_docker_registry_config(name)
+  def restart_docker_registry_service(name)
     ChefSpec::Matchers::ResourceMatcher.new(:docker_registry_service, :restart, name)
   end
 


### PR DESCRIPTION
Matchers for docker_registry_service not working due to their names.
Use *_service instead of *_config.
